### PR TITLE
Roman/fix documentation

### DIFF
--- a/broker/README.md
+++ b/broker/README.md
@@ -4,10 +4,11 @@
 
 ## Installation
 
-To install the mosquitto broker as a service (Debian with systemd) use the following command:
+To install the mosquitto broker as a service (Debian with systemd) use the following commands as root:
 
 ```bash
-sudo ./broker/broker-service-install.sh
+cd /broker
+./broker-service-install.sh
 ```
 
 ## Configuration

--- a/manager/README.md
+++ b/manager/README.md
@@ -2,13 +2,6 @@
 
 *manager* contains the telemersive-manager
 
-## Requirement
-
-* nodejs needs to be available
-
-```
-apt install nodejs
-```
 
 ## Installation
 
@@ -17,7 +10,8 @@ Important for the installation is that first the broker is installed and second 
 Installs the manager together with NPM if it is not installed already.
 
 ```bash
-sudo ./manager/manager-service-install.sh
+cd manager
+./manager-service-install.sh
 ```
 
 ## Configuration

--- a/manager/manager-service-install.sh
+++ b/manager/manager-service-install.sh
@@ -18,8 +18,8 @@ sudo apt install acl -y
 
 # installing node
 curl -fsSL https://deb.nodesource.com/setup_15.x | bash -
-sudo apt-get install -y nodejs
-sudo apt-get install gcc g++ make
+apt-get update
+apt-get install -y acl nodejs npm gcc g++ make
 
 # add user
 echo "adding service user..."

--- a/nat-helper/nat-helper-service-install.sh
+++ b/nat-helper/nat-helper-service-install.sh
@@ -21,7 +21,7 @@ setfacl -R -m u:$SERVICE_USER_NAME:rwx "$SCRIPT_PATH"
 # prepare service configuration form template
 echo "installing service..."
 RUN_SCRIPT_PATH="$SCRIPT_PATH/nat-helper"
-cp "nat-helper/$SERVICE_NAME.service.txt" "$SERVICE_NAME.service"
+cp "./$SERVICE_NAME.service.txt" "$SERVICE_NAME.service"
 
 sed -i -e "s~%COMMAND%~$RUN_SCRIPT_PATH~g" "$SERVICE_NAME.service"
 sed -i -e "s~%USER%~$SERVICE_USER_NAME~g" "$SERVICE_NAME.service"

--- a/switchboard/README.md
+++ b/switchboard/README.md
@@ -43,7 +43,8 @@ We also need to create a template session that is automatically loaded in a new 
 To install the switchboard as a service (Debian with systemd) use the following command:
 
 ```bash
-./switchboard/switchboard-service-install.sh
+cd switchboard
+./switchboard-service-install.sh
 ```
 
 The recommended way of running *Telemersive Switchboard* is to execute it under [gunicorn](https://gunicorn.org/). The included script `setup.sh` automates the process of setting up Telemersive Switchboard* as a system service. The script is tested on *Debian* and *Ubuntu*. Run it as root:

--- a/switchboard/README.md
+++ b/switchboard/README.md
@@ -9,45 +9,22 @@ It is written in [Python](https://www.python.org/) and uses the
 [flask](https://flask.palletsprojects.com/) framework.
 
 
-## Requirement
+## Requirements
 
-### Installing OpenStageControl
+The following requirements are automatically installed when using the installation script
+described in the next section:
 
-[OpenStageControl](https://openstagecontrol.ammd.net/) is a web application that allows the easy creation of user interfaces and is seamlessly integrated in the telemersive toolkit:
-
-```bash
-sudo apt install gdebi-core wget
-wget "https://github.com/jean-emmanuel/open-stage-control/releases/download/v1.26.2/open-stage-control_1.26.2_amd64.deb"
-sudo gdebi open-stage-control_1.26.2_amd64.deb
-```
-
-### Setup OpenStageControl for instantiating by switchboard
-
-When an instance of the `OpenStageControl` module is started, it automatically creates a folder named after the room and copies
-a default session to that new folder. Thus, we need to make sure the folder exists and the user OpenStageControl runs under has
-access to it:
-
-```bash
-sudo mkdir -p /opt/open-stage-control/sessions/tsb_sessions
-sudo chown -R telemersive-switchboard:telemersive-switchboard /opt/open-stage-control/sessions
-```
-
-We also need to create a template session that is automatically loaded in a new room and save it under this path:  
-
-```bash
-/opt/open-stage-control/sessions/tsb_sessions/template.json
-```
+  * [OpenStageControl](https://openstagecontrol.ammd.net/) is a web application that allows the easy creation of user interfaces and is seamlessly integrated in the telemersive toolkit. It is automatically installed when following the steps below.
+ *  [gunicorn](https://gunicorn.org/):Python WSGI HTTP Server for UNIX
 
 ## Installation
 
-To install the switchboard as a service (Debian with systemd) use the following command:
+To install the switchboard as a service (Debian with systemd) use the following command as root:
 
 ```bash
 cd switchboard
 ./switchboard-service-install.sh
 ```
-
-The recommended way of running *Telemersive Switchboard* is to execute it under [gunicorn](https://gunicorn.org/). The included script `setup.sh` automates the process of setting up Telemersive Switchboard* as a system service. The script is tested on *Debian* and *Ubuntu*. Run it as root:
 
 ## Configuration
 

--- a/switchboard/switchboard-service-install.sh
+++ b/switchboard/switchboard-service-install.sh
@@ -11,7 +11,7 @@ LOG_DIR="/var/log/telemersive-switchboard"
 LISTEN_PORT=3591
 LISTEN_ADDRESS="0.0.0.0"
 DEB_PKGS="python3-flask gunicorn3 gdebi-core wget"
-OSC_DEB="https://github.com/jean-emmanuel/open-stage-control/releases/download/v1.25.5/open-stage-control_1.25.5_amd64.deb"
+OSC_DEB="https://github.com/jean-emmanuel/open-stage-control/releases/download/v1.26.2/open-stage-control_1.26.2_amd64.deb"
 
 function hilite {
   echo -ne "\033[32m"


### PR DESCRIPTION
Ich hab einige Kleinigkeiten in den READMEs und auch in den Skripts geflickt.  So wie die Scripts geschrieben sind, müssen sie im eigenen Ordner ausgeführt werden, da sie sonst ihre .cfg Datei nicht finden. Ich hab's mal in den READMEs so angepasst. Man könnte alternativ die Skripts anpassen.

Bestimmte Anleitungen waren  überflüssig, da sich die Skripts bereits darum kümmern, z.Bsp OpenStageControl, oder auch nodejs. Letzteres sollte eben grad nicht vorgängig manuell installiert werden, da man so die Version von Debian kriegt. Das Skript installiert aber nachher die Version aus nodesource. npm hat im Skript für den Manager gefehlt und darum haben einige Schritte gar nicht funktioniert. Da das Skript für den Manager kein Error-Handling hat, merkt man es auch nicht. Es sollte jetzt durchlaufen, aber Error-Handling hat es immer noch keines.

Der telemersive-manager.service hat immer noch Fehler,  er kann glaubs nicht mit dem Broker verbinden, obwohl ich beidseits user:password auf manager:manager gesetzt habe. Was habe ich da falsch gemacht?

```
May 28 10:35:05 telemersive manager-run.sh[21892]: connecting to broker...
May 28 10:35:06 telemersive manager-run.sh[21892]: /opt/telemersive-router/manager/node_modules/mqtt/lib/client.js:1382
May 28 10:35:06 telemersive manager-run.sh[21892]:     const err = new Error('Connection refused: ' + errors[rc])
May 28 10:35:06 telemersive manager-run.sh[21892]:                 ^
May 28 10:35:06 telemersive manager-run.sh[21892]: Error: Connection refused: Not authorized
May 28 10:35:06 telemersive manager-run.sh[21892]:     at MqttClient._handleConnack (/opt/telemersive-router/manager/node_modules/mqtt/lib/client.js:1382:17)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at MqttClient._handlePacket (/opt/telemersive-router/manager/node_modules/mqtt/lib/client.js:543:12)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at work (/opt/telemersive-router/manager/node_modules/mqtt/lib/client.js:430:12)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at writable._write (/opt/telemersive-router/manager/node_modules/mqtt/lib/client.js:444:5)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at doWrite (/opt/telemersive-router/manager/node_modules/readable-stream/lib/_stream_writable.js:390:139)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at writeOrBuffer (/opt/telemersive-router/manager/node_modules/readable-stream/lib/_stream_writable.js:381:5)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at Writable.write (/opt/telemersive-router/manager/node_modules/readable-stream/lib/_stream_writable.js:302:11)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at Socket.ondata (node:internal/streams/readable:809:22)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at Socket.emit (node:events:517:28)
May 28 10:35:06 telemersive manager-run.sh[21892]:     at addChunk (node:internal/streams/readable:368:12) {
May 28 10:35:06 telemersive manager-run.sh[21892]:   code: 5
May 28 10:35:06 telemersive manager-run.sh[21892]: }

```

Der telemersive-manager.service zeigt auch Fehler, die aber auch auf telemersion erscheinen und offenbar keine Probleme machen. Unschön ist es trotzdem:

```
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! code EACCES
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! syscall mkdir
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! path /home/telemersive_manager
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! errno -13
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! Error: EACCES: permission denied, mkdir '/home/telemersive_manager'
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR!  [Error: EACCES: permission denied, mkdir '/home/telemersive_manager'] {
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR!   errno: -13,
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR!   code: 'EACCES',
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR!   syscall: 'mkdir',
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR!   path: '/home/telemersive_manager'
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! }
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR!
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! The operation was rejected by your operating system.
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! It is likely you do not have the permissions to access this file as the current user
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR!
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! If you believe this might be a permissions issue, please double-check the
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! permissions of the file and its containing directories, or try running
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! the command again as root/Administrator.
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! Log files were not written due to an error writing to the directory: /home/telemersive_manager/.npm/_logs
May 28 10:35:05 telemersive manager-run.sh[21855]: npm ERR! You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
```
